### PR TITLE
Cmdline symbol processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dyescape</groupId>
     <artifactId>kotlin-maven-symbol-processing</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <name>Kotlin Maven Symbol Processing</name>
     <description>Kotlin Symbol Processing extension for the kotlin maven plugin</description>
@@ -54,8 +54,14 @@
         </dependency>
         <dependency>
             <groupId>com.google.devtools.ksp</groupId>
-            <artifactId>symbol-processing</artifactId>
+            <artifactId>symbol-processing-cmdline</artifactId>
             <version>1.6.20-1.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-compiler</artifactId>
+            <version>1.6.20</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -111,7 +117,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>com.google.devtools.ksp:symbol-processing</include>
+                                    <include>com.google.devtools.ksp:symbol-processing-cmdline</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -241,6 +247,7 @@
 
     <scm>
         <url>https://github.com/Dyescape/kotlin-maven-symbol-processing</url>
-        <developerConnection>scm:git:ssh://git@github.com:Dyescape/kotlin-maven-symbol-processing.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com:Dyescape/kotlin-maven-symbol-processing.git
+        </developerConnection>
     </scm>
 </project>


### PR DESCRIPTION
Due to the `symbol-processing` artifact using `kotlin-compiler-embeddable`, which includes relocated dependencies, using the plugin with other compiler plugins in maven causes issues with method signatures.

Switching to `symbol-processing-cmdline` fixes this, as it is not a CLI for KSP, but actually the variant for the non-embeddable `kotlin-compiler`.
