### PR TITLE
Bump to kotlin 1.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
     </developers>
 
     <properties>
+        <dokka.version>1.8.10</dokka.version>
+        <kotlin.version>1.8.10</kotlin.version>
+        <ksp.version>1.8.10-1.0.9</ksp.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -50,23 +54,23 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.devtools.ksp</groupId>
             <artifactId>symbol-processing-cmdline</artifactId>
-            <version>1.8.0-Beta-1.0.8</version>
+            <version>${ksp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-compiler</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-plugin</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -78,7 +82,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.8.0-Beta</version>
+                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -190,7 +194,7 @@
                     <plugin>
                         <groupId>org.jetbrains.dokka</groupId>
                         <artifactId>dokka-maven-plugin</artifactId>
-                        <version>1.7.20</version>
+                        <version>${dokka.version}</version>
                         <executions>
                             <execution>
                                 <phase>prepare-package</phase>


### PR DESCRIPTION
I have built and tested this locally on my ksp project (https://github.com/MorphiaOrg/critter) and it works quite well on kotlin 1.8.10.  I could really use a 1.5 release so I can use this is my other projects already on 1.8.