### PR TITLE
Upgrade kotlin version to 1.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,23 +50,23 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>1.8.10</version>
         </dependency>
         <dependency>
             <groupId>com.google.devtools.ksp</groupId>
             <artifactId>symbol-processing-cmdline</artifactId>
-            <version>1.8.0-Beta-1.0.8</version>
+            <version>1.8.10-1.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-compiler</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>1.8.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-plugin</artifactId>
-            <version>1.8.0-Beta</version>
+            <version>1.8.10</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.8.0-Beta</version>
+                <version>1.8.10</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>shade</id>


### PR DESCRIPTION
Same as #88, but without using maven properties in Versions, because those seem to confuse Dependabot.